### PR TITLE
Fix typo when include header hdr10plus.h

### DIFF
--- a/source/encoder/encoder.h
+++ b/source/encoder/encoder.h
@@ -31,7 +31,7 @@
 #include "x265.h"
 #include "nal.h"
 #include "framedata.h"
-#include "dynamicHDR10\hdr10plus.h"
+#include "dynamicHDR10/hdr10plus.h"
 
 struct x265_encoder {};
 namespace X265_NS {


### PR DESCRIPTION
Here is typo, and can not build in ubuntu.