### PR TITLE
Correct check for valid UHDBD resolutions

### DIFF
--- a/source/encoder/encoder.cpp
+++ b/source/encoder/encoder.cpp
@@ -3090,7 +3090,7 @@ void Encoder::configure(x265_param *p)
             x265_log(p, X265_LOG_ERROR, "uhd-bd: matrix coeffs supported are either BT.709 or BT.2020\n");
             disableUhdBd = 1;
         }
-        if ((p->sourceWidth != 1920 && p->sourceWidth != 3840) || (p->sourceHeight != 1080 && p->sourceHeight != 2160))
+        if (!((p->sourceWidth == 1920 && p->sourceHeight == 1080) || (p->sourceWidth == 3840 && p->sourceHeight == 2160)))
         {
             x265_log(p, X265_LOG_ERROR, "uhd-bd: Supported resolutions are 1920x1080 and 3840x2160\n");
             disableUhdBd = 1;


### PR DESCRIPTION
Existing check would validate 1920x2160 and 3840x1080. New check validates permutation.