### PR TITLE
x265: fix build with cmake 4

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -6,18 +6,12 @@ if(NOT CMAKE_BUILD_TYPE)
         FORCE)
 endif()
 message(STATUS "cmake version ${CMAKE_VERSION}")
-if(POLICY CMP0025)
-    cmake_policy(SET CMP0025 OLD) # report Apple's Clang as just Clang
-endif()
 if(POLICY CMP0042)
     cmake_policy(SET CMP0042 NEW) # MACOSX_RPATH
 endif()
-if(POLICY CMP0054)
-    cmake_policy(SET CMP0054 OLD) # Only interpret if() arguments as variables or keywords when unquoted
-endif()
 
 project (x265)
-cmake_minimum_required (VERSION 2.8.8) # OBJECT libraries require 2.8.8
+cmake_minimum_required (VERSION 2.8.8...4.0) # OBJECT libraries require 2.8.8
 include(CheckIncludeFiles)
 include(CheckFunctionExists)
 include(CheckSymbolExists)

--- a/source/dynamicHDR10/CMakeLists.txt
+++ b/source/dynamicHDR10/CMakeLists.txt
@@ -10,7 +10,7 @@ add_library(dynamicHDR10 OBJECT
     hdr10plus.h
     api.cpp )
 
-cmake_minimum_required (VERSION 2.8.11)
+cmake_minimum_required (VERSION 2.8.11...4.0)
 project(dynamicHDR10)
 include(CheckIncludeFiles)
 include(CheckFunctionExists)


### PR DESCRIPTION
Drop policies that have been removed in cmake 4 and allow to build with cmake 4.0

